### PR TITLE
Model Serializer Map

### DIFF
--- a/generic_relations/utils.py
+++ b/generic_relations/utils.py
@@ -4,8 +4,4 @@ from django.utils.module_loading import import_string
 class ModelSerializerMap(UserDict): # Ideally dict should be subclassed
 
     def __getitem__(self, item):
-        # print(item in self.data)
-        # print(item, self.data.items())
-        # print({import_string(k): import_string(v)() for k, v in self.data.items()})
-        # print(item in (import_string(k) for k in self.data.keys()), [import_string(k) for k in self.data.keys()])
         return {k: import_string(v)() for k, v in self.data.items()}.get(item,None)

--- a/generic_relations/utils.py
+++ b/generic_relations/utils.py
@@ -1,7 +1,16 @@
 from collections import UserDict
 from django.utils.module_loading import import_string
 
-class ModelSerializerMap(UserDict): # Ideally dict should be subclassed
+class ModelSerializerMap(UserDict): 
+    """\
+    Mapping model classes to serializer classes
+    
+    This dictionery is instantiated with the import paths for one or more model(s) for the keys and the preferred serializer for each model as the value(s).
+    When a key is later accessed the instantiated serializer is returned in place of its input path. ::
+    
+        ModelSerializerMap{"APP.models.MODEL":"APP.serializers.SERIALIZER"}["APP.models.MODEL"] => APP.serializers.SERIALIZER()
+    """
+    # Ideally dict should be subclassed
 
     def __getitem__(self, item):
         return {k: import_string(v)() for k, v in self.data.items()}.get(item,None)

--- a/generic_relations/utils.py
+++ b/generic_relations/utils.py
@@ -1,0 +1,11 @@
+from collections import UserDict
+from django.utils.module_loading import import_string
+
+class ModelSerializerMap(UserDict): # Ideally dict should be subclassed
+
+    def __getitem__(self, item):
+        # print(item in self.data)
+        # print(item, self.data.items())
+        # print({import_string(k): import_string(v)() for k, v in self.data.items()})
+        # print(item in (import_string(k) for k in self.data.keys()), [import_string(k) for k in self.data.keys()])
+        return {k: import_string(v)() for k, v in self.data.items()}.get(item,None)


### PR DESCRIPTION
Hi,

I was using your library for a project and needed the {model:serializer} mapping to be configured in the websites' settings. The `dict` provided in this commit allows one to configure this in the sites settings and access the `Serializers` lazily; since importing serializers within the settings module occurs before all applications are loaded.  

Usage example :

    PACKAGE_MODEL_FIELD_SERIALIZERS = ModelSerializerMap(**{"APPLICATION.models.MODEL":"APPLICATION.serializers.SERIALIZER"})

Please consider adding this to the libray.